### PR TITLE
No confirmation when a fragment is about to be moved out of site

### DIFF
--- a/src/main/resources/assets/js/app/browse/action/MoveContentAction.ts
+++ b/src/main/resources/assets/js/app/browse/action/MoveContentAction.ts
@@ -10,9 +10,9 @@ export class MoveContentAction extends Action {
         super(i18n('action.moveMore'));
         this.setEnabled(false);
         this.onExecuted(() => {
-            let contents: api.content.ContentSummaryAndCompareStatus[]
+            const contents: api.content.ContentSummaryAndCompareStatus[]
                 = grid.getSelectedDataList();
-            new MoveContentEvent(contents, grid.getRoot().getCurrentRoot()).fire();
+            new MoveContentEvent(contents, grid.getRoot().getDefaultRoot()).fire();
         });
     }
 }


### PR DESCRIPTION
-Setting default root for MoveContentEvent thus when contents filtered default root will be used to find parent of moved content