### PR TITLE
CKEditor - Incorrect behaviour of context menu

### DIFF
--- a/src/main/resources/assets/js/page-editor/text/TextComponentViewCK.ts
+++ b/src/main/resources/assets/js/page-editor/text/TextComponentViewCK.ts
@@ -250,7 +250,7 @@ export class TextComponentViewCK
     }
 
     isActive(): boolean {
-        return this.hasClass('active');
+        return this.hasClass(TextComponentViewCK.EDITOR_FOCUSED_CLASS);
     }
 
     setEditMode(flag: boolean) {


### PR DESCRIPTION
-fixed isActive() check so editor's context menu works as supposed (used to close immediately after opening)