### PR TITLE
Issue Details Dialog and Create Issue Dialog - incorrect layout in It…

### DIFF
--- a/src/main/resources/assets/styles/publish/issue-details-dialog.less
+++ b/src/main/resources/assets/styles/publish/issue-details-dialog.less
@@ -169,10 +169,6 @@
 
     &.contains-toggleable {
 
-      .browse-selection-item:not(.toggleable) {
-        margin-left: @toggler-width;
-      }
-
       .include-children-toggler {
         cursor: default;
         &:hover {

--- a/src/main/resources/assets/styles/publish/issue-dialog.less
+++ b/src/main/resources/assets/styles/publish/issue-dialog.less
@@ -70,10 +70,6 @@
 
       &.contains-toggleable {
 
-        .browse-selection-item:not(.toggleable) {
-          margin-left: @toggler-width;
-        }
-
         .include-children-toggler {
           cursor: pointer;
           &.readonly {


### PR DESCRIPTION
…ems, when a child has been added #141

Removed unnecessary margin in the elements without children, that is compensated by the margin in the `.viewer` in `dependant-items-dialog`.