### PR TITLE
Issue Details Dialog - links in 'items' list should be clickable, whe…

### DIFF
--- a/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
+++ b/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
@@ -50,7 +50,10 @@
 
     &.readonly {
       .browse-selection-item {
-        pointer-events: none;
+        .remove,
+        .include-children-toggler {
+          pointer-events: none;
+        }
       }
     }
 


### PR DESCRIPTION
…n issue is closed #142

Updated items list in Read-only mode, allowing the click on the items itself (opens content in the new tab) and disallowing the click on the togglers and button, that modify those items.