### PR TITLE
Content Wizard - all inputs and buttons should be disabled when user …

### DIFF
--- a/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -69,6 +69,8 @@ export class PageComponentsView
 
     private textComponentsKeyupHandlers: any = {};
 
+    private writePermissions: boolean = false;
+
     constructor(liveEditPage: LiveEditPageProxy, private saveAsTemplateAction: SaveAsTemplateAction) {
         super('page-components-view');
 
@@ -177,6 +179,11 @@ export class PageComponentsView
         if (!this.tree && this.content && this.pageView) {
             this.createTree(this.content, this.pageView);
         }
+    }
+
+    setWritePermissions(writePermissions: boolean): boolean {
+        this.writePermissions = writePermissions;
+        return this.writePermissions;
     }
 
     private initLiveEditEvents() {
@@ -651,7 +658,9 @@ export class PageComponentsView
         event.stopPropagation();
         event.preventDefault();
 
-        if (!this.pageView.isLocked()) {
+        const isUnlocked = !(this.pageView.isLocked() && this.writePermissions);
+
+        if (isUnlocked) {
             return;
         }
 

--- a/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
+++ b/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
@@ -260,6 +260,8 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
             let hasPublishPermission = api.security.acl.PermissionHelper.hasPermission(api.security.acl.Permission.PUBLISH,
                 loginResult, existing.getPermissions());
 
+            (<PreviewAction>this.actionsMap.PREVIEW).setWritePermissions(this.hasModifyPermission);
+
             if (!this.hasModifyPermission) {
                 this.enableActions({SAVE: false, SAVE_AND_CLOSE: false});
             }

--- a/src/main/resources/assets/js/app/wizard/action/PreviewAction.ts
+++ b/src/main/resources/assets/js/app/wizard/action/PreviewAction.ts
@@ -5,10 +5,12 @@ import i18n = api.util.i18n;
 
 export class PreviewAction extends BasePreviewAction {
 
+    private writePermissions: boolean = false;
+
     constructor(wizard: ContentWizardPanel) {
         super(i18n('action.preview'));
         this.onExecuted(() => {
-                if (wizard.hasUnsavedChanges()) {
+            if (wizard.hasUnsavedChanges() && this.writePermissions) {
                     wizard.setRequireValid(true);
                     wizard.saveChanges().then(content => this.openWindow(content)).catch(
                         (reason: any) => api.DefaultErrorHandler.handle(reason)).done();
@@ -17,5 +19,9 @@ export class PreviewAction extends BasePreviewAction {
                 }
             }
         );
+    }
+
+    setWritePermissions(writePermissions: boolean) {
+        this.writePermissions = writePermissions;
     }
 }

--- a/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
@@ -122,6 +122,8 @@ export class LiveEditPageProxy {
 
     private controllerCopyForIE: any;
 
+    private writePermissions: boolean = false;
+
     constructor() {
 
         this.liveEditIFrame = this.createLiveEditIFrame();
@@ -163,6 +165,11 @@ export class LiveEditPageProxy {
 
     public setModel(liveEditModel: LiveEditModel) {
         this.liveEditModel = liveEditModel;
+    }
+
+    public setWritePermissions(writePermissions: boolean): boolean {
+        this.writePermissions = writePermissions;
+        return this.writePermissions;
     }
 
     public setWidth(value: string) {
@@ -332,7 +339,7 @@ export class LiveEditPageProxy {
                 if (LiveEditPageProxy.debug) {
                     console.debug('LiveEditPageProxy.hanldeIframeLoadedEvent: initialize live edit at ' + new Date().toISOString());
                 }
-                new InitializeLiveEditEvent(this.liveEditModel).fire(this.liveEditWindow);
+                new InitializeLiveEditEvent(this.liveEditModel, this.writePermissions).fire(this.liveEditWindow);
             } else {
                 if (LiveEditPageProxy.debug) {
                     console.debug('LiveEditPageProxy.handleIframeLoadedEvent: notify live edit ready at ' + new Date().toISOString());

--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -805,4 +805,17 @@ export class LiveFormPanel
             listener(pageView);
         });
     }
+
+    updateWritePermissions(writePermissions: boolean): boolean {
+        let result = null;
+        if (this.insertablesPanel) {
+            const insertablesResult = this.insertablesPanel.setWritePermissions(writePermissions);
+            result = result && insertablesResult;
+        }
+        if (this.liveEditPageProxy) {
+            const liveEditResult = this.liveEditPageProxy.setWritePermissions(writePermissions);
+            result = result && liveEditResult;
+        }
+        return result;
+    }
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/insert/InsertablesPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/insert/InsertablesPanel.ts
@@ -43,6 +43,8 @@ export class InsertablesPanel
 
     private contextWindowDraggable: JQuery;
 
+    private writePermissions: boolean = false;
+
     public static debug: boolean = false;
 
     constructor(config: ComponentTypesPanelConfig) {
@@ -84,6 +86,14 @@ export class InsertablesPanel
 
         this.insertablesGrid.onRendered(this.initializeDraggables.bind(this));
         this.onRemoved(this.destroyDraggables.bind(this));
+    }
+
+    setWritePermissions(writePermissions: boolean): boolean {
+        this.writePermissions = writePermissions;
+        if (this.componentsView) {
+            return this.componentsView.setWritePermissions(writePermissions);
+        }
+        return null;
     }
 
     getComponentsView(): PageComponentsView {
@@ -130,6 +140,10 @@ export class InsertablesPanel
             console.log('InsertablesPanel.handleDragStart', event, ui);
         }
 
+        if (!this.writePermissions) {
+            return;
+        }
+
         ui.helper.show();
 
         this.liveEditPageProxy.getDragMask().show();
@@ -140,7 +154,7 @@ export class InsertablesPanel
 
     private handleDrag(event: JQueryEventObject, ui: JQueryUI.DraggableEventUIParams) {
 
-        if (!this.pageView) {
+        if (!this.pageView || !this.writePermissions) {
             // page view is either not ready or there was an error
             // so there is no point in handling drag inside it
             return;

--- a/src/main/resources/assets/js/main.ts
+++ b/src/main/resources/assets/js/main.ts
@@ -300,7 +300,7 @@ function startContentWizard(wizardParams: ContentWizardPanelParams, connectionDe
         if (wizard.isContentDeleted() || !connectionDetector.isConnected() || !connectionDetector.isAuthenticated()) {
             return;
         }
-        if (wizard.hasUnsavedChanges()) {
+        if (wizard.hasUnsavedChanges() && wizard.hasWritePermissions()) {
             let message = i18n('dialog.wizard.unsavedChanges');
             // Hack for IE. returnValue is boolean
             const e: any = event || window.event || {returnValue: ''};

--- a/src/main/resources/assets/js/page-editor/InitializeLiveEditEvent.ts
+++ b/src/main/resources/assets/js/page-editor/InitializeLiveEditEvent.ts
@@ -6,13 +6,20 @@ export class InitializeLiveEditEvent
 
     private liveEditModel: LiveEditModel;
 
-    constructor(liveEditModel: LiveEditModel) {
+    private writePermissions: boolean;
+
+    constructor(liveEditModel: LiveEditModel, writePermissions: boolean = false) {
         super();
         this.liveEditModel = liveEditModel;
+        this.writePermissions = writePermissions;
     }
 
     getLiveEditModel(): LiveEditModel {
         return this.liveEditModel;
+    }
+
+    hasWritePermissions(): boolean {
+        return this.writePermissions;
     }
 
     static on(handler: (event: InitializeLiveEditEvent) => void, contextWindow: Window = window) {

--- a/src/main/resources/assets/js/page-editor/LiveEditPage.ts
+++ b/src/main/resources/assets/js/page-editor/LiveEditPage.ts
@@ -65,7 +65,8 @@ export class LiveEditPage {
 
         api.util.i18nInit(CONFIG.messages);
 
-        let liveEditModel = event.getLiveEditModel();
+        const liveEditModel = event.getLiveEditModel();
+        const writePermissions = event.hasWritePermissions();
 
         let body = api.dom.Body.get().loadExistingChildren();
         try {
@@ -73,6 +74,7 @@ export class LiveEditPage {
                 .setItemViewIdProducer(new ItemViewIdProducer())
                 .setItemViewFactory(new DefaultItemViewFactory())
                 .setLiveEditModel(liveEditModel)
+                .setWritePermissions(writePermissions)
                 .setElement(body).build();
         } catch (error) {
             if (LiveEditPage.debug) {

--- a/src/main/resources/assets/js/page-editor/PageView.ts
+++ b/src/main/resources/assets/js/page-editor/PageView.ts
@@ -53,6 +53,8 @@ export class PageViewBuilder {
 
     element: api.dom.Body;
 
+    writePermissions: boolean = false;
+
     setLiveEditModel(value: LiveEditModel): PageViewBuilder {
         this.liveEditModel = value;
         return this;
@@ -70,6 +72,11 @@ export class PageViewBuilder {
 
     setElement(value: api.dom.Body): PageViewBuilder {
         this.element = value;
+        return this;
+    }
+
+    setWritePermissions(writePermissions: boolean): PageViewBuilder {
+        this.writePermissions = writePermissions;
         return this;
     }
 
@@ -123,6 +130,8 @@ export class PageView
 
     private isCKEditor: boolean;
 
+    private writePermissions: boolean;
+
     constructor(builder: PageViewBuilder) {
 
         super(new ItemViewBuilder()
@@ -135,6 +144,8 @@ export class PageView
             .setContextMenuTitle(new PageViewContextMenuTitle(builder.liveEditModel.getContent())));
 
         this.isCKEditor = CONFIG.isCkeUsed;
+
+        this.writePermissions = builder.writePermissions;
 
         this.setPlaceholder(new PagePlaceholder(this));
 
@@ -166,10 +177,10 @@ export class PageView
         // lock page by default for every content that has not been modified except for page template
         let isCustomized = this.liveEditModel.getPageModel().isCustomized();
         let isFragment = !!this.fragmentView;
-        if (!this.pageModel.isPageTemplate() && !isCustomized && !isFragment) {
+        const lockable = !this.pageModel.isPageTemplate() && !isCustomized && !isFragment;
+        if (lockable || !this.writePermissions) {
             this.setLocked(true);
         }
-
     }
 
     private registerPageViewController() {
@@ -439,7 +450,7 @@ export class PageView
         let unlockAction = new api.ui.Action(i18n('live.view.page.customize'));
 
         unlockAction.onExecuted(() => {
-            this.setLocked(false);
+            this.setLocked(false); //
         });
 
         return [unlockAction];
@@ -461,7 +472,7 @@ export class PageView
     }
 
     handleShaderClick(event: MouseEvent) {
-        if (this.isLocked()) {
+        if (this.isLocked() && this.writePermissions) {
             if (!this.lockedContextMenu) {
                 this.lockedContextMenu = this.createLockedContextMenu();
             }
@@ -526,7 +537,7 @@ export class PageView
         this.toggleClass('force-locked', visible);
     }
 
-    setLocked(locked: boolean) {
+    setLocked(locked: boolean) { //
         this.toggleClass('locked', locked);
 
         this.hideContextMenu();

--- a/src/main/resources/assets/styles/main.less
+++ b/src/main/resources/assets/styles/main.less
@@ -26,6 +26,8 @@
 @import "wizard/edit-permissions-dialog";
 @import "wizard/page-components-view";
 @import "wizard/content/wizard-preview-dialog";
+@import "wizard/page/contextwindow/emulator-panel";
+@import "wizard/page/contextwindow/insertables-panel";
 @import "wizard/page/contextwindow/inspections-panel";
 @import "wizard/page/contextwindow/context-window";
 @import "wizard/security-wizard-step-form";

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -293,6 +293,19 @@
       }
     }
   }
+
+  &.no-write-permissions {
+    .thumbnail-uploader-el, .wizard-header, .wizard-steps-panel {
+      * {
+        pointer-events: none;
+      }
+      .@{_COMMON_PREFIX}text-input,
+      .text-area,
+      .help-text-toggler {
+        pointer-events: all;
+      }
+    }
+  }
 }
 
 ._0-240, ._240-360, ._360-540, ._540-720, ._720-960, .mce-fullscreen {

--- a/src/main/resources/assets/styles/wizard/page/contextwindow/context-window.less
+++ b/src/main/resources/assets/styles/wizard/page/contextwindow/context-window.less
@@ -72,12 +72,6 @@
       height: auto;
     }
 
-    .insertables-panel &:hover {
-      cursor: -moz-grab;
-      cursor: -webkit-grab;
-      cursor: grab;
-    }
-
     h5 {
       margin: 0;
       padding: 0;
@@ -121,42 +115,6 @@
         display: block;
       }
     }
-  }
-
-  .insertables-panel {
-    p {
-      font-size: 12px;
-      padding: 10px 15px;
-    }
-
-    & > .button-bar {
-      left: 5px;
-      position: absolute;
-      bottom: 0;
-      right: 0;
-      padding: 6px;
-      text-align: center;
-      background-color: white;
-    }
-  }
-
-  .emulator-panel {
-    p {
-      font-size: 12px;
-      padding: 10px 15px;
-    }
-    .grid-row.active {
-      background-color: @admin-bg-light-gray;
-
-      h5, h6 {
-        color: @admin-black;
-      }
-
-      .@{_CLS_PREFIX}font-icon:before {
-        color: @admin-button-blue1;
-      }
-    }
-
   }
 
   .inspection-panel {

--- a/src/main/resources/assets/styles/wizard/page/contextwindow/emulator-panel.less
+++ b/src/main/resources/assets/styles/wizard/page/contextwindow/emulator-panel.less
@@ -1,0 +1,18 @@
+.emulator-panel {
+  p {
+    font-size: 12px;
+    padding: 10px 15px;
+  }
+  .grid-row.active {
+    background-color: @admin-bg-light-gray;
+
+    h5, h6 {
+      color: @admin-black;
+    }
+
+    .@{_CLS_PREFIX}font-icon:before {
+      color: @admin-button-blue1;
+    }
+  }
+
+}

--- a/src/main/resources/assets/styles/wizard/page/contextwindow/insertables-panel.less
+++ b/src/main/resources/assets/styles/wizard/page/contextwindow/insertables-panel.less
@@ -1,0 +1,26 @@
+.insertables-panel {
+  &:hover {
+    cursor: grab;
+  }
+
+  p {
+    font-size: 12px;
+    padding: 10px 15px;
+  }
+
+  & > .button-bar {
+    left: 5px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    padding: 6px;
+    text-align: center;
+    background-color: white;
+  }
+}
+
+.no-write-permissions {
+  .insertables-panel {
+    pointer-events: none;
+  }
+}

--- a/src/main/resources/assets/styles/wizard/page/contextwindow/inspections-panel.less
+++ b/src/main/resources/assets/styles/wizard/page/contextwindow/inspections-panel.less
@@ -32,3 +32,9 @@
     }
   }
 }
+
+.no-write-permissions {
+  .inspections-panel {
+    pointer-events: none;
+  }
+}

--- a/src/main/resources/assets/styles/wizard/security-wizard-step-form.less
+++ b/src/main/resources/assets/styles/wizard/security-wizard-step-form.less
@@ -1,11 +1,4 @@
 .security-wizard-step-form {
-
-  &.no-write-permissions {
-    .edit-permissions {
-      display: none;
-    }
-  }
-
   .edit-permissions {
     .button(@form-button-font, @form-button-bg);
     display: inline-block;
@@ -42,5 +35,12 @@
     }
 
   }
+}
 
+.no-write-permissions {
+  .security-wizard-step-form {
+    .edit-permissions {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
…has 'Read Only' access to the content #32

Added `writePermissions` flag for `WRITE` permission check.
Disabled forms and live edit, when user has no permissions.
Disabled page save on close or before preview, if some enabled inputs were modified.
Disabled page unlocking for user with insufficient permissions.
Kept text inputs enabled to be able to copy content.