### PR TITLE
Fix margin of the items in Publish dialog

### DIFF
--- a/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
+++ b/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
@@ -38,12 +38,15 @@
 
     &.contains-toggleable {
       .browse-selection-item:not(.toggleable) {
-        .include-children-toggler {
-          display: block;
-          visibility: hidden;
-        }
         .viewer {
           margin-left: 35px;
+        }
+        .include-children-toggler {
+          & + .viewer {
+            margin-left: 0;
+          }
+          display: block;
+          visibility: hidden;
         }
       }
     }


### PR DESCRIPTION
Removed margin for the items, that are already published, but has children (toggler is hidden).