### PR TITLE
CKE: in live edit cke's internal elements not removed when saving #293

### DIFF
--- a/src/main/resources/assets/js/page-editor/text/TextComponentViewCK.ts
+++ b/src/main/resources/assets/js/page-editor/text/TextComponentViewCK.ts
@@ -460,7 +460,7 @@ export class TextComponentViewCK
             // copy editor raw content (without any processing!) over to the root html element
             this.rootElement.getHTMLElement().innerHTML = this.htmlAreaEditor.getSnapshot();
             // but save processed text to the component
-            this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getSnapshot()));
+            this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getData()));
         }
     }
 


### PR DESCRIPTION
-have to use getData() instead of getSnapshot(), that makes everything cleanup