### PR TITLE
Edit Permissions Dialog - incorrect state for 'Inherit permissions' c…

### DIFF
--- a/src/main/resources/assets/js/app/wizard/EditPermissionsDialog.ts
+++ b/src/main/resources/assets/js/app/wizard/EditPermissionsDialog.ts
@@ -83,9 +83,9 @@ export class EditPermissionsDialog
 
             this.comboBox.toggleClass('disabled', this.inheritPermissions);
             if (this.inheritPermissions) {
-                this.layoutInheritedPermissions()
+                this.layoutInheritedPermissions();
             } else {
-                this.layoutOriginalPermissions()
+                this.layoutOriginalPermissions();
             }
 
             this.comboBox.getComboBox().setVisible(!this.inheritPermissions);

--- a/src/main/resources/assets/js/app/wizard/EditPermissionsDialog.ts
+++ b/src/main/resources/assets/js/app/wizard/EditPermissionsDialog.ts
@@ -79,14 +79,17 @@ export class EditPermissionsDialog
         };
 
         let changeListener = () => {
-            const inheritPermissions = this.inheritPermissionsCheck.isChecked();
+            this.inheritPermissions = this.inheritPermissionsCheck.isChecked();
 
-            this.comboBox.toggleClass('disabled', inheritPermissions);
+            this.comboBox.toggleClass('disabled', this.inheritPermissions);
+            if (this.inheritPermissions) {
+                this.layoutInheritedPermissions()
+            } else {
+                this.layoutOriginalPermissions()
+            }
 
-            inheritPermissions ? this.layoutInheritedPermissions() : this.layoutOriginalPermissions();
-
-            this.comboBox.getComboBox().setVisible(!inheritPermissions);
-            this.comboBox.setReadOnly(inheritPermissions);
+            this.comboBox.getComboBox().setVisible(!this.inheritPermissions);
+            this.comboBox.setReadOnly(this.inheritPermissions);
 
             comboBoxChangeListener();
         };
@@ -122,13 +125,13 @@ export class EditPermissionsDialog
             this.getParentPermissions().then((parentPermissions: AccessControlList) => {
                 this.parentPermissions = parentPermissions.getEntries();
 
+                this.open();
+
                 this.setUpDialog();
 
                 this.overwriteChildPermissionsCheck.setChecked(this.overwritePermissions, true);
 
                 changeListener();
-
-                this.open();
 
             }).catch(() => {
                 api.notify.showWarning(i18n('notify.permissions.inheritError', this.displayName));


### PR DESCRIPTION
…heckbox when the dialog is opened in the second time #277

Moved dialog setup after it is opened, since it may be initialized with default form values in `open()` method, if it wasn't present in the DOM.