### PR TITLE
Browser console errors after drag'n'dropping a text component #377

### DIFF
--- a/src/main/resources/assets/js/page-editor/PageView.ts
+++ b/src/main/resources/assets/js/page-editor/PageView.ts
@@ -351,14 +351,6 @@ export class PageView
         return this.hasClass('has-toolbar-container');
     }
 
-    getEditorToolbarContainerId(): string {
-        if (this.editorToolbar) {
-            return this.editorToolbar.getId();
-        }
-
-        return null;
-    }
-
     private setIgnorePropertyChanges(value: boolean) {
         this.ignorePropertyChanges = value;
     }

--- a/src/main/resources/assets/js/page-editor/PageViewController.ts
+++ b/src/main/resources/assets/js/page-editor/PageViewController.ts
@@ -80,4 +80,12 @@ export class PageViewController {
     isNextClickDisabled(): boolean {
         return this.nextClickDisabled;
     }
+
+    getEditorToolbarContainerId(): string {
+        if (this.editorToolbar) {
+            return this.editorToolbar.getId();
+        }
+
+        return null;
+    }
 }

--- a/src/main/resources/assets/js/page-editor/text/TextComponentViewCK.ts
+++ b/src/main/resources/assets/js/page-editor/text/TextComponentViewCK.ts
@@ -410,7 +410,7 @@ export class TextComponentViewCK
             .setMouseLeaveHandler(this.onMouseLeftHandler.bind(this))
             .setKeydownHandler(keydownHandler)
             .setNodeChangeHandler(this.processEditorValue.bind(this))
-            .setFixedToolbarContainer(this.getPageView().getEditorToolbarContainerId())
+            .setFixedToolbarContainer(PageViewController.get().getEditorToolbarContainerId())
             .setContent(this.getContent())
             .setEditableSourceCode(this.editableSourceCode)
             .setContentPath(this.getContentPath())


### PR DESCRIPTION
-PageView is not always available by the time editor is initialized, thus taking fixed toolbar container id from PageController;