### PR TITLE
Grid is not refreshed when switching between Inbound and Outbound dep…

### DIFF
--- a/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -70,6 +70,9 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
     }
 
     public setDependencyItem(item: ContentSummary, inbound: boolean) {
+        if (inbound !== this.dependenciesSection.getInbound()) {
+            this.dependenciesSection.reset();
+        }
         this.dependenciesSection.setInbound(inbound);
         this.setConstraintItems(this.dependenciesSection, [ContentSummaryAndCompareStatus.fromContentSummary(item)]);
     }
@@ -480,6 +483,10 @@ export class DependenciesSection extends api.app.browse.filter.ConstraintSection
 
     public isOutbound(): boolean {
         return this.isActive() && !this.inbound;
+    }
+
+    public getInbound(): boolean {
+        return this.inbound;
     }
 
     public setInbound(inbound: boolean) {


### PR DESCRIPTION
…endencies #371

-When switching between inbound/outbound dependencies it's constraint items doesn't seem to change for BrowseFilterPanel; Resetting Dependencies section in case of switching inbound/outbound thus BrowseFilterPanel processes constraints