### PR TITLE
Dependencies Widget - Open dependencies in a new browser tab

### DIFF
--- a/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -5,6 +5,7 @@ import {SortContentEvent} from './browse/SortContentEvent';
 import {OpenSortDialogEvent} from './browse/OpenSortDialogEvent';
 import {MoveContentEvent} from './move/MoveContentEvent';
 import {OpenMoveDialogEvent} from './move/OpenMoveDialogEvent';
+import {ShowDependenciesEvent} from './browse/ShowDependenciesEvent';
 import AppBarTabId = api.app.bar.AppBarTabId;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import ContentUpdatedEvent = api.content.event.ContentUpdatedEvent;
@@ -23,7 +24,12 @@ export class ContentEventsProcessor {
             // contents of the same type simultaneously
             wizardId = tabId.toString();
         }
-        return window.open(wizardUrl, wizardId);
+
+        return ContentEventsProcessor.openTab(wizardUrl, wizardId);
+    }
+
+    static openTab(url: string, target?: string): Window {
+        return window.open(url, target);
     }
 
     static popupBlocked(win: Window) {
@@ -88,5 +94,13 @@ export class ContentEventsProcessor {
 
         let contents: ContentSummaryAndCompareStatus[] = event.getModels();
         new OpenMoveDialogEvent(contents.map(content => content.getContentSummary()), event.getRootNode()).fire();
+    }
+
+    static handleShowDependencies(event: ShowDependenciesEvent) {
+        const mode: string = event.isInbound() ? 'inbound' : 'outbound';
+        const id: string = event.getId().toString();
+        const url = `main#/${mode}/${id}`;
+
+        ContentEventsProcessor.openTab(url);
     }
 }

--- a/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -5,6 +5,7 @@ import {TreeNodesOfContentPath} from './TreeNodesOfContentPath';
 import {TreeNodeParentOfContent} from './TreeNodeParentOfContent';
 import {ContentTreeGridToolbar} from './ContentTreeGridToolbar';
 import {ActiveContentVersionSetEvent} from '../event/ActiveContentVersionSetEvent';
+import {ContentTreeGridLoadedEvent} from './ContentTreeGridLoadedEvent';
 import ElementHelper = api.dom.ElementHelper;
 
 import TreeGrid = api.ui.treegrid.TreeGrid;
@@ -179,6 +180,10 @@ export class ContentTreeGrid
         });
         ActiveContentVersionSetEvent.on((event: ActiveContentVersionSetEvent) => {
             this.updateContentNode(event.getContentId());
+        });
+
+        this.onLoaded(() => {
+            new ContentTreeGridLoadedEvent().fire();
         });
     }
 

--- a/src/main/resources/assets/js/app/browse/ContentTreeGridLoadedEvent.ts
+++ b/src/main/resources/assets/js/app/browse/ContentTreeGridLoadedEvent.ts
@@ -1,0 +1,13 @@
+import '../../api.ts';
+
+export class ContentTreeGridLoadedEvent
+    extends api.event.Event {
+
+    static on(handler: (event: ContentTreeGridLoadedEvent) => void) {
+        api.event.Event.bind(api.ClassHelper.getFullName(this), handler);
+    }
+
+    static un(handler?: (event: ContentTreeGridLoadedEvent) => void) {
+        api.event.Event.unbind(api.ClassHelper.getFullName(this), handler);
+    }
+}

--- a/src/main/resources/assets/js/app/browse/ShowDependenciesEvent.ts
+++ b/src/main/resources/assets/js/app/browse/ShowDependenciesEvent.ts
@@ -1,0 +1,32 @@
+import '../../api.ts';
+import ContentId = api.content.ContentId;
+
+export class ShowDependenciesEvent
+    extends api.event.Event {
+
+    private id: ContentId;
+
+    private inbound: boolean;
+
+    constructor(id: ContentId, inbound: boolean) {
+        super();
+        this.id = id;
+        this.inbound = inbound;
+    }
+
+    getId(): ContentId {
+        return this.id;
+    }
+
+    isInbound(): boolean {
+        return this.inbound;
+    }
+
+    static on(handler: (event: ShowDependenciesEvent) => void, contextWindow: Window = window) {
+        api.event.Event.bind(api.ClassHelper.getFullName(this), handler, contextWindow);
+    }
+
+    static un(handler?: (event: ShowDependenciesEvent) => void, contextWindow: Window = window) {
+        api.event.Event.unbind(api.ClassHelper.getFullName(this), handler, contextWindow);
+    }
+}

--- a/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -1,5 +1,6 @@
 import {ContentBrowseSearchData} from './ContentBrowseSearchData';
 import {ContentTypeAggregationGroupView} from './ContentTypeAggregationGroupView';
+import {Router} from '../../Router';
 import ContentQueryRequest = api.content.resource.ContentQueryRequest;
 import ContentTypeName = api.schema.content.ContentTypeName;
 import ContentSummaryJson = api.content.json.ContentSummaryJson;
@@ -67,6 +68,7 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
         this.resetConstraints();
         this.dependenciesSection.reset();
         this.search();
+        Router.back();
     }
 
     public setDependencyItem(item: ContentSummary, inbound: boolean) {

--- a/src/main/resources/assets/js/app/view/detail/widget/dependency/DependenciesWidgetItemView.ts
+++ b/src/main/resources/assets/js/app/view/detail/widget/dependency/DependenciesWidgetItemView.ts
@@ -1,11 +1,11 @@
 import '../../../../../api.ts';
 import {WidgetItemView} from '../../WidgetItemView';
 import {DependencyGroup, DependencyType} from './DependencyGroup';
-import {ToggleSearchPanelWithDependenciesEvent} from '../../../../browse/ToggleSearchPanelWithDependenciesEvent';
 import {ResolveDependenciesRequest} from '../../../../resource/ResolveDependenciesRequest';
 import {ContentDependencyJson} from '../../../../resource/json/ContentDependencyJson';
 import {ResolveDependencyResult} from '../../../../resource/ResolveDependencyResult';
 import {ResolveDependenciesResult} from '../../../../resource/ResolveDependenciesResult';
+import {ShowDependenciesEvent} from '../../../../browse/ShowDependenciesEvent';
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import ActionButton = api.ui.button.ActionButton;
 import Action = api.ui.Action;
@@ -39,12 +39,12 @@ export class DependenciesWidgetItemView
     }
 
     private manageButtonClick() {
-        this.inboundButton.getAction().onExecuted((action: Action) => {
-            new ToggleSearchPanelWithDependenciesEvent(this.item.getContentSummary(), true).fire();
+        this.inboundButton.getAction().onExecuted(() => {
+            new ShowDependenciesEvent(this.item.getContentId(), true).fire();
         });
 
-        this.outboundButton.getAction().onExecuted((action: Action) => {
-            new ToggleSearchPanelWithDependenciesEvent(this.item.getContentSummary(), false).fire();
+        this.outboundButton.getAction().onExecuted(() => {
+            new ShowDependenciesEvent(this.item.getContentId(), false).fire();
         });
     }
 

--- a/src/main/resources/assets/js/main.ts
+++ b/src/main/resources/assets/js/main.ts
@@ -41,6 +41,7 @@ import {ContentDuplicateDialog} from './app/duplicate/ContentDuplicateDialog';
 import {ContentDuplicatePromptEvent} from './app/browse/ContentDuplicatePromptEvent';
 import {ShowIssuesDialogButton} from './app/issue/view/ShowIssuesDialogButton';
 import {GetContentTypeByNameRequest} from './app/resource/GetContentTypeByNameRequest';
+import {ShowDependenciesEvent} from './app/browse/ShowDependenciesEvent';
 
 function getApplication(): api.app.Application {
     let application = new api.app.Application('content-studio', i18n('app.name'), i18n('app.abbr'), CONFIG.appIconUrl);
@@ -289,6 +290,8 @@ function startApplication() {
 
     ShowIssuesDialogEvent.on((event: ShowIssuesDialogEvent) =>
         IssueDialogsManager.get().openListDialog(event.getAssignedToMe(), event.getCreatedByMe()));
+
+    ShowDependenciesEvent.on(ContentEventsProcessor.handleShowDependencies);
 
     // tslint:disable-next-line:no-unused-expression
     new EditPermissionsDialog();


### PR DESCRIPTION
…ns to open a new browser tab #376

-Firing ShowDependenciesEvent on inbound/outbound buttons clicked
-Setting router's hash for new tab as inbound/contentId or outbound/contentId
-When new tab is opened waiting for grid to be loaded (ContentTreeGridLoadedEvent) and then triggering dependency filter, otherwise treegrid might be loaded after filter applied