### PR TITLE
Content's Dependencies Widget should be refreshed, when new inbound d…

### DIFF
--- a/src/main/resources/assets/js/app/view/detail/DetailsView.ts
+++ b/src/main/resources/assets/js/app/view/detail/DetailsView.ts
@@ -69,12 +69,28 @@ export class DetailsView extends api.dom.DivEl {
     }
 
     private subscribeOnEvents() {
+        const serverEventsHandler = api.content.event.ContentServerEventsHandler.getInstance();
+
         ActiveContentVersionSetEvent.on((event: ActiveContentVersionSetEvent) => {
             if (ActiveDetailsPanelManager.getActiveDetailsPanel().isVisibleOrAboutToBeVisible() && !!this.activeWidget &&
                 this.activeWidget.getWidgetName() === i18n('field.widget.versionHistory')) {
                 this.updateActiveWidget();
             }
         });
+
+        const dependenciesWidgetUpdateHandler = AppHelper.debounce(this.updateDependenciesWidget.bind(this), 1000);
+
+        serverEventsHandler.onContentDuplicated(dependenciesWidgetUpdateHandler);
+        serverEventsHandler.onContentUpdated(dependenciesWidgetUpdateHandler);
+        serverEventsHandler.onContentDeleted(dependenciesWidgetUpdateHandler);
+    }
+
+    private updateDependenciesWidget() {
+        if (!this.activeWidget || !this.activeWidget.hasClass('dependency-widget')) {
+            return;
+        }
+
+        this.activeWidget.updateWidgetItemViews(true);
     }
 
     private initDivForNoSelection() {


### PR DESCRIPTION
…ependency has been added or removed #374

-Unable to determine whenever some content starts/stops referencing content in dependencies widget; Updating dependencies widget in case any content was updated/deleted/duplicated, using debounce to reduce number of invocations