### PR TITLE
Browser console errors when swapping text components after save #390

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -470,6 +470,11 @@ export class LiveFormPanel
 
             this.pageLoading = true;
 
+            this.insertablesPanel.getComponentsView().addClass('loading');
+            this.liveEditPageProxy.onLoaded(() => {
+                this.insertablesPanel.getComponentsView().removeClass('loading');
+            });
+
             this.liveEditPageProxy.load();
 
             if (clearInspection) {

--- a/src/main/resources/assets/styles/wizard/page-components-view.less
+++ b/src/main/resources/assets/styles/wizard/page-components-view.less
@@ -32,7 +32,7 @@
     }
   }
 
-  &.locked {
+  &.locked, &.loading {
     .grid {
       pointer-events: none;
     }


### PR DESCRIPTION
-Error occured because while saving wizard you might start dragging item before page and PageComponentsTreeGrid is reloaded; When PageComponentsTreeGrid is reloaded and you're still dragging - error occurs. Solved by disabling pointer events on grid until page and PageComponentsTreeGrid is reloaded