### PR TITLE
Esc key does not close the Issue List dialog #316

### DIFF
--- a/src/main/resources/assets/js/app/issue/IssueDialogsManager.ts
+++ b/src/main/resources/assets/js/app/issue/IssueDialogsManager.ts
@@ -39,9 +39,9 @@ export class IssueDialogsManager {
         let ignoreNextClosedEvent = false;
         dialog.onIssueCreated(issue => {
             ignoreNextClosedEvent = true;
+            dialog.close();
             this.notifyIssueCreated(issue);
             this.openDetailsDialog(issue);
-            dialog.close();
         });
         dialog.onClosed(() => {
             if (!ignoreNextClosedEvent) {


### PR DESCRIPTION
-Have to close CreateIssueDialog before opening DetailsDialog to not break keybindings shelve/unshelve order;