### PR TITLE
Tab with dependencies should be refreshed when content was changed #456

### DIFF
--- a/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -212,7 +212,10 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
         } else if (this.hasSearchStringSet()) { // if still no result and search text is set remove last modified facet
             this.deselectAll();
             return this.searchDataAndHandleResponse(this.cloneContentQueryNoAggregations(contentQuery));
+        } else if (this.dependenciesSection.isActive()) {
+            this.removeDependencyItem();
         }
+
         return this.reset();
     }
 


### PR DESCRIPTION
-Listening delete content event in content filter panel to handle situation when dependencies section item was deleted
-Listening update event to trigger filter search in case when dependencies section item was updated (because dependencies could be added or removed)