### PR TITLE
Dependencies widget - Enable opening Content Wizard for dependencies …

### DIFF
--- a/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -99,7 +99,8 @@ export class ContentEventsProcessor {
     static handleShowDependencies(event: ShowDependenciesEvent) {
         const mode: string = event.isInbound() ? 'inbound' : 'outbound';
         const id: string = event.getId().toString();
-        const url = `main#/${mode}/${id}`;
+        const type: string = event.getContentType() ? event.getContentType().toString() : null;
+        const url = !!type ? `main#/${mode}/${id}/${type}` : `main#/${mode}/${id}`;
 
         ContentEventsProcessor.openTab(url);
     }

--- a/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -260,7 +260,7 @@ export class ContentBrowsePanel
             }
 
             this.showFilterPanel();
-            this.filterPanel.setDependencyItem(event.getContent(), event.isInbound());
+            this.filterPanel.setDependencyItem(event.getContent(), event.isInbound(), event.getType());
         });
 
         NewMediaUploadEvent.on((event) => {

--- a/src/main/resources/assets/js/app/browse/ShowDependenciesEvent.ts
+++ b/src/main/resources/assets/js/app/browse/ShowDependenciesEvent.ts
@@ -1,5 +1,6 @@
 import '../../api.ts';
 import ContentId = api.content.ContentId;
+import ContentTypeName = api.schema.content.ContentTypeName;
 
 export class ShowDependenciesEvent
     extends api.event.Event {
@@ -8,10 +9,13 @@ export class ShowDependenciesEvent
 
     private inbound: boolean;
 
-    constructor(id: ContentId, inbound: boolean) {
+    private contentType: ContentTypeName;
+
+    constructor(id: ContentId, inbound: boolean, contentType?: ContentTypeName) {
         super();
         this.id = id;
         this.inbound = inbound;
+        this.contentType = contentType;
     }
 
     getId(): ContentId {
@@ -20,6 +24,10 @@ export class ShowDependenciesEvent
 
     isInbound(): boolean {
         return this.inbound;
+    }
+
+    getContentType(): ContentTypeName {
+        return this.contentType;
     }
 
     static on(handler: (event: ShowDependenciesEvent) => void, contextWindow: Window = window) {

--- a/src/main/resources/assets/js/app/browse/ToggleSearchPanelWithDependenciesEvent.ts
+++ b/src/main/resources/assets/js/app/browse/ToggleSearchPanelWithDependenciesEvent.ts
@@ -7,10 +7,13 @@ export class ToggleSearchPanelWithDependenciesEvent extends api.event.Event {
 
     private inbound: boolean;
 
-    constructor(item: ContentSummary, inbound: boolean) {
+    private type: string;
+
+    constructor(item: ContentSummary, inbound: boolean, type?: string) {
         super();
         this.item = item;
         this.inbound = inbound;
+        this.type = type;
     }
 
     getContent(): ContentSummary {
@@ -19,6 +22,10 @@ export class ToggleSearchPanelWithDependenciesEvent extends api.event.Event {
 
     isInbound(): boolean {
         return this.inbound;
+    }
+
+    getType(): string {
+        return this.type;
     }
 
     static on(handler: (event: ToggleSearchPanelWithDependenciesEvent) => void, contextWindow: Window = window) {

--- a/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -106,9 +106,18 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
         Router.back();
     }
 
-    public setDependencyItem(item: ContentSummary, inbound: boolean) {
-        this.dependenciesSection.setInbound(inbound);
+    public setDependencyItem(item: ContentSummary, inbound: boolean, type?: string) {
+        this.dependenciesSection.setInbound(inbound).setType(type);
         this.setConstraintItems(this.dependenciesSection, [ContentSummaryAndCompareStatus.fromContentSummary(item)]);
+        this.selectContentTypeBucket(type);
+    }
+
+    private selectContentTypeBucket(key: string) {
+        if (!key) {
+            return;
+        }
+
+        (<api.aggregation.BucketAggregationView>this.contentTypeAggregation.getAggregationViews()[0]).selectBucketViewByKey(key);
     }
 
     doRefresh(): wemQ.Promise<void>  {
@@ -497,6 +506,7 @@ export class DependenciesSection extends api.app.browse.filter.ConstraintSection
     private viewer: ContentSummaryViewer = new ContentSummaryViewer();
 
     private inbound: boolean = true;
+    private type: string;
 
     constructor(closeCallback: () => void) {
         super('', closeCallback);
@@ -514,6 +524,10 @@ export class DependenciesSection extends api.app.browse.filter.ConstraintSection
         return this.getItems()[0];
     }
 
+    public getType(): string {
+        return this.type;
+    }
+
     public isInbound(): boolean {
         return this.isActive() && this.inbound;
     }
@@ -522,9 +536,15 @@ export class DependenciesSection extends api.app.browse.filter.ConstraintSection
         return this.isActive() && !this.inbound;
     }
 
-    public setInbound(inbound: boolean) {
+    public setInbound(inbound: boolean): DependenciesSection {
         this.inbound = inbound;
         this.setLabel(inbound ? i18n('panel.filter.dependencies.inbound') : i18n('panel.filter.dependencies.outbound'));
+        return this;
+    }
+
+    public setType(type: string): DependenciesSection {
+        this.type = type;
+        return this;
     }
 
     public setItems(items: ContentSummaryAndCompareStatus[]) {

--- a/src/main/resources/assets/js/app/resource/ResolveDependenciesResult.ts
+++ b/src/main/resources/assets/js/app/resource/ResolveDependenciesResult.ts
@@ -19,8 +19,9 @@ export class ResolveDependenciesResult {
         this.dependencies.forEach(dependencyResult => {
             const dependency = dependencyResult.getDependency();
             const contentId = dependencyResult.getContentId().toString();
+
             if (dependency.inbound && dependency.inbound.length > 0) {
-                object[contentId] = dependency.inbound.reduce((sum, dep) => sum + dep.count, 0);
+                object[contentId] = dependency.inbound.reduce((sum, dep) => sum + dep.contents.length, 0);
             }
         });
 

--- a/src/main/resources/assets/js/app/resource/json/ContentDependencyGroupJson.ts
+++ b/src/main/resources/assets/js/app/resource/json/ContentDependencyGroupJson.ts
@@ -1,8 +1,8 @@
 export interface ContentDependencyGroupJson {
 
-    count: number;
-
     iconUrl: string;
 
     type: string;
+
+    contents: api.content.json.ContentSummaryJson[];
 }

--- a/src/main/resources/assets/js/app/view/detail/widget/dependency/DependenciesWidgetItemView.ts
+++ b/src/main/resources/assets/js/app/view/detail/widget/dependency/DependenciesWidgetItemView.ts
@@ -9,8 +9,10 @@ import {ShowDependenciesEvent} from '../../../../browse/ShowDependenciesEvent';
 import {ContentSummaryAndCompareStatus} from '../../../../content/ContentSummaryAndCompareStatus';
 import ActionButton = api.ui.button.ActionButton;
 import Action = api.ui.Action;
+import NamesAndIconView = api.app.NamesAndIconView;
 import NamesAndIconViewSize = api.app.NamesAndIconViewSize;
 import NamesAndIconViewBuilder = api.app.NamesAndIconViewBuilder;
+import Tooltip = api.ui.Tooltip;
 import i18n = api.util.i18n;
 
 export class DependenciesWidgetItemView
@@ -58,8 +60,8 @@ export class DependenciesWidgetItemView
     }
 
     private appendButton(label: string, cls: string): ActionButton {
-        let action = new Action(label);
-        let button = new ActionButton(action);
+        const action = new Action(label);
+        const button = new ActionButton(action);
 
         button.addClass(cls);
         this.appendChild(button);
@@ -101,8 +103,9 @@ export class DependenciesWidgetItemView
     }
 
     private createDependenciesContainer(type: DependencyType, dependencies: DependencyGroup[]): api.dom.DivEl {
-        let typeAsString = DependencyType[type].toLowerCase();
-        let div = new api.dom.DivEl('dependencies-container ' + typeAsString);
+        const typeAsString = DependencyType[type].toLowerCase();
+        const div = new api.dom.DivEl('dependencies-container ' + typeAsString);
+
         if (dependencies.length === 0) {
             this.addClass('no-' + typeAsString);
             div.addClass('no-dependencies');
@@ -138,16 +141,32 @@ export class DependenciesWidgetItemView
 
     private appendDependencies(container: api.dom.DivEl, dependencies: DependencyGroup[]) {
         dependencies.forEach((dependencyGroup: DependencyGroup) => {
-            let dependencyGroupView = new api.app.NamesAndIconView(new NamesAndIconViewBuilder().setSize(NamesAndIconViewSize.small))
-                .setIconUrl(dependencyGroup.getIconUrl())
-                .setMainName('(' + dependencyGroup.getItemCount().toString() + ')');
-
-            /* Tooltip is buggy
-            dependencyGroupView.getEl().setTitle(dependencyGroup.getName());
-            */
-
-            container.appendChild(dependencyGroupView);
+            container.appendChild(this.createDependencyGroupView(dependencyGroup));
         });
+    }
+
+    private createDependencyGroupView(dependencyGroup: DependencyGroup): NamesAndIconView {
+        const dependencyGroupView = new NamesAndIconView(new NamesAndIconViewBuilder().setSize(NamesAndIconViewSize.small))
+            .setIconUrl(dependencyGroup.getIconUrl())
+            .setMainName('(' + dependencyGroup.getItemCount().toString() + ')');
+
+        this.handleDependencyGroupClick(dependencyGroupView, dependencyGroup);
+        this.createDependencyGroupTooltip(dependencyGroupView, dependencyGroup);
+
+        return dependencyGroupView;
+    }
+
+    private handleDependencyGroupClick(dependencyGroupView: NamesAndIconView, dependencyGroup: DependencyGroup) {
+        dependencyGroupView.getIconImageEl().onClicked(() => {
+            new ShowDependenciesEvent(this.item.getContentId(), dependencyGroup.getType() === DependencyType.INBOUND,
+                dependencyGroup.getContentType()).fire();
+        });
+    }
+
+    private createDependencyGroupTooltip(dependencyGroupView: NamesAndIconView, dependencyGroup: DependencyGroup) {
+        let tooltipText: string = '';
+        dependencyGroup.getDependencies().forEach(value => tooltipText += value.getPath() + '\n');
+        new Tooltip(dependencyGroupView.getIconImageEl(), tooltipText, 200).setMode(Tooltip.MODE_GLOBAL_STATIC).setSide(Tooltip.SIDE_LEFT);
     }
 
     /**
@@ -155,7 +174,7 @@ export class DependenciesWidgetItemView
      */
     private resolveDependencies(item: ContentSummaryAndCompareStatus): wemQ.Promise<any> {
 
-        let resolveDependenciesRequest = new ResolveDependenciesRequest([item.getContentId()]);
+        const resolveDependenciesRequest = new ResolveDependenciesRequest([item.getContentId()]);
 
         return resolveDependenciesRequest.sendAndParse().then((result: ResolveDependenciesResult) => {
             const dependencyEntry: ResolveDependencyResult = result.getDependencies()[0];

--- a/src/main/resources/assets/js/app/view/detail/widget/dependency/DependencyGroup.ts
+++ b/src/main/resources/assets/js/app/view/detail/widget/dependency/DependencyGroup.ts
@@ -1,6 +1,7 @@
 import '../../../../../api.ts';
 import {ContentDependencyGroupJson} from '../../../../resource/json/ContentDependencyGroupJson';
 import ContentTypeName = api.schema.content.ContentTypeName;
+import ContentSummary = api.content.ContentSummary;
 
 export enum DependencyType {
     INBOUND,
@@ -9,23 +10,23 @@ export enum DependencyType {
 
 export class DependencyGroup implements api.Equitable {
 
-    private itemCount: number;
-
     private iconUrl: string;
 
     private contentType: ContentTypeName;
 
     private type: DependencyType;
 
+    private dependencies: ContentSummary[];
+
     constructor(builder: DependencyGroupBuilder) {
-        this.itemCount = builder.itemCount;
         this.iconUrl = builder.iconUrl;
         this.contentType = builder.contentType;
         this.type = builder.type;
+        this.dependencies = builder.dependencies;
     }
 
     getItemCount(): number {
-        return this.itemCount;
+        return this.dependencies.length;
     }
 
     getIconUrl(): string {
@@ -40,8 +41,12 @@ export class DependencyGroup implements api.Equitable {
         return this.contentType.toString();
     }
 
-    getType(): string {
-        return DependencyType[this.type];
+    getType(): DependencyType {
+        return this.type;
+    }
+
+    getDependencies(): ContentSummary[] {
+        return this.dependencies;
     }
 
     equals(o: api.Equitable): boolean {
@@ -52,7 +57,7 @@ export class DependencyGroup implements api.Equitable {
 
         let other = <DependencyGroup>o;
 
-        if (!api.ObjectHelper.numberEquals(this.itemCount, other.itemCount)) {
+        if (!api.ObjectHelper.numberEquals(this.dependencies.length, other.dependencies.length)) {
             return false;
         }
         if (!api.ObjectHelper.equals(this.contentType, other.contentType)) {
@@ -77,26 +82,26 @@ export class DependencyGroup implements api.Equitable {
 
 export class DependencyGroupBuilder {
 
-    itemCount: number;
-
     iconUrl: string;
 
     contentType: api.schema.content.ContentTypeName;
 
     type: DependencyType;
 
+    dependencies: ContentSummary[];
+
     constructor(source?: DependencyGroup) {
         if (source) {
-            this.itemCount = source.getItemCount();
             this.iconUrl = source.getIconUrl();
             this.contentType = source.getContentType();
+            this.dependencies = source.getDependencies();
         }
     }
 
     fromJson(json: ContentDependencyGroupJson): DependencyGroupBuilder {
-        this.itemCount = json.count;
         this.iconUrl = json.iconUrl;
         this.contentType = new ContentTypeName(json.type);
+        this.dependencies = json.contents.map(contentSummaryJson => ContentSummary.fromJson(contentSummaryJson));
 
         return this;
     }

--- a/src/main/resources/assets/styles/view/detail/widget-dependency.less
+++ b/src/main/resources/assets/styles/view/detail/widget-dependency.less
@@ -162,6 +162,10 @@
 
           .@{_COMMON_PREFIX}wrapper {
             line-height: 30px;
+
+            img {
+              cursor: pointer;
+            }
           }
 
           .@{_COMMON_PREFIX}names-view {


### PR DESCRIPTION
…#490

-Added a tooltip over the content type icon showing the list of content item paths, one per line.
-Clicking on content type will open the list of dependencies filtered by content type, same as for example "Show outbound" button, but with the content-type preset in the filter + grid filtered by this content type.