### PR TITLE
Endless spinner in grid with 'DependenciesSection', after removing re…

### DIFF
--- a/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -181,11 +181,13 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
             .setExpand(api.rest.Expand.SUMMARY)
             .sendAndParse()
             .then((contentQueryResult: ContentQueryResult<ContentSummary,ContentSummaryJson>) => {
-                this.handleDataSearchResult(contentQuery, contentQueryResult);
+                if (this.dependenciesSection.isActive() && contentQueryResult.getAggregations().length === 0) {
+                    this.removeDependencyItem();
+                } else {
+                    return this.handleDataSearchResult(contentQuery, contentQueryResult);
+                }
             })
-            .catch((reason: any) => {
-                api.DefaultErrorHandler.handle(reason);
-        });
+            .catch(api.DefaultErrorHandler.handle);
     }
 
     private refreshDataAndHandleResponse(contentQuery: ContentQuery): wemQ.Promise<void>  {
@@ -199,14 +201,12 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
                     this.handleNoSearchResultOnRefresh(contentQuery);
                 }
             })
-            .catch((reason: any) => {
-                api.DefaultErrorHandler.handle(reason);
-        });
+            .catch(api.DefaultErrorHandler.handle);
     }
 
     private handleDataSearchResult(contentQuery: ContentQuery,
                                    contentQueryResult: ContentQueryResult<ContentSummary,ContentSummaryJson>) {
-        this.getAggregations(contentQuery, contentQueryResult).then((aggregations: Aggregation[]) => {
+        return this.getAggregations(contentQuery, contentQueryResult).then((aggregations: Aggregation[]) => {
             this.updateAggregations(aggregations, true);
             this.updateHitsCounter(contentQueryResult.getMetadata().getTotalHits());
             this.toggleAggregationsVisibility(contentQueryResult.getAggregations());


### PR DESCRIPTION
…lated component in Page Editor #577

-Situation when referenced content is no longer referenced was not handled properly
-Returning promises so .catch() works as supposed to