### PR TITLE
Internal alignment styles are not working in Page Editor #596

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -18,6 +18,7 @@ import ContentPath = api.content.ContentPath;
 /**
  * NB: Using inline styles for editor's inline mode; Inline styles apply same alignment styles as alignment classes
  * in xp/styles.css, thus don't forget to update inline styles when styles.css modified
+ * NB: CKE rearranges order of entries in classes and style attributes, might trim whitespaces or semicolon
  */
 export class HtmlEditor {
 
@@ -53,6 +54,7 @@ export class HtmlEditor {
             if (e.data.name === 'image') {
                 e.data.allowedContent.figure.classes = ['*'];
                 e.data.allowedContent.figure.styles = ['*'];
+                e.data.allowedContent.img.styles = ['*'];
             }
         });
     }
@@ -86,6 +88,7 @@ export class HtmlEditor {
             setTimeout(() => {
                 rootElement.find('figure').toArray().forEach((figure: CKEDITOR.dom.element) => {
                     HtmlEditor.updateFigureInlineStyle(figure);
+                    HtmlEditor.updateImageInlineStyle(figure);
                     HtmlEditor.sortFigureClasses(figure);
                 });
             }, 1);
@@ -141,7 +144,7 @@ export class HtmlEditor {
                 const dataSrc: string = ImageUrlBuilder.RENDER.imagePrefix + imageId;
 
                 this.replaceWith(`<figure class="captioned ${StyleHelper.STYLE.ALIGNMENT.JUSTIFY.CLASS}">` +
-                                 `<img src="${upload.url}" data-src="${dataSrc}">` +
+                                 `<img src="${upload.url}" data-src="${dataSrc}" style="max-height: 100%; max-width: 100%; width: 100%">` +
                                  '<figcaption> </figcaption>' +
                                  '</figure>');
             };
@@ -324,7 +327,8 @@ export class HtmlEditor {
     }
 
     private doUpdateAlignmentButtonStates(figure: CKEDITOR.dom.element) {
-        if (figure.hasClass(StyleHelper.STYLE.ALIGNMENT.JUSTIFY.CLASS)) {
+        // class 'undefined' means newly inserted justified image
+        if (figure.hasClass(StyleHelper.STYLE.ALIGNMENT.JUSTIFY.CLASS) || figure.hasClass('undefined')) {
             this.setJustifyButtonActive();
         } else {
             this.toggleToolbarButtonState('justifyblock', false);
@@ -417,6 +421,14 @@ export class HtmlEditor {
     public static sortFigureClasses(figure: CKEDITOR.dom.element) {
         const classes: string[] = figure.$.className.split(' ').sort();
         figure.$.className = classes.join(' ');
+    }
+
+    public static updateImageInlineStyle(figure: CKEDITOR.dom.element) {
+        const img: CKEDITOR.dom.element = figure.findOne('img');
+
+        if (img) {
+            img.setAttribute('style', 'max-height:100%; max-width:100%; width:100%');
+        }
     }
 
     private handleNativeNotifications() {

--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -141,9 +141,7 @@ export class HtmlEditor {
                 const dataSrc: string = ImageUrlBuilder.RENDER.imagePrefix + imageId;
 
                 this.replaceWith(`<figure class="captioned ${StyleHelper.STYLE.ALIGNMENT.JUSTIFY.CLASS}">` +
-                                 `<img src="${upload.url}" data-src="${dataSrc}"` +
-                                 `width="${this.parts.img.$.naturalWidth}" ` +
-                                 `height="${this.parts.img.$.naturalHeight}">` +
+                                 `<img src="${upload.url}" data-src="${dataSrc}">` +
                                  '<figcaption> </figcaption>' +
                                  '</figure>');
             };

--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -28,6 +28,8 @@ export class HtmlEditor {
 
     private hasActiveDialog: boolean = false;
 
+    private static readonly imgInlineStyle = 'max-height:100%; max-width:100%; width:100%';
+
     private constructor(config: CKEDITOR.config, htmlEditorParams: HtmlEditorParams) {
         this.editorParams = htmlEditorParams;
 
@@ -137,6 +139,7 @@ export class HtmlEditor {
     // Wrapping dropped image into figure element
     private handleImageDropped() {
         const editor = this.editor;
+        const imgInlineStyle = HtmlEditor.imgInlineStyle;
 
         this.editor.on('instanceReady', function () {
             (<any>editor.widgets.registered.uploadimage).onUploaded = function (upload: any) {
@@ -144,7 +147,7 @@ export class HtmlEditor {
                 const dataSrc: string = ImageUrlBuilder.RENDER.imagePrefix + imageId;
 
                 this.replaceWith(`<figure class="captioned ${StyleHelper.STYLE.ALIGNMENT.JUSTIFY.CLASS}">` +
-                                 `<img src="${upload.url}" data-src="${dataSrc}" style="max-height: 100%; max-width: 100%; width: 100%">` +
+                                 `<img src="${upload.url}" data-src="${dataSrc}" style="${imgInlineStyle}">` +
                                  '<figcaption> </figcaption>' +
                                  '</figure>');
             };
@@ -427,7 +430,7 @@ export class HtmlEditor {
         const img: CKEDITOR.dom.element = figure.findOne('img');
 
         if (img) {
-            img.setAttribute('style', 'max-height:100%; max-width:100%; width:100%');
+            img.setAttribute('style', HtmlEditor.imgInlineStyle);
         }
     }
 

--- a/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
@@ -505,6 +505,7 @@ export class ImageModalDialog
         imageEl.removeAttribute('style');
 
         this.updateImageSrc(imageEl.$, this.editorWidth);
+        HtmlEditor.updateImageInlineStyle(figureEl);
 
         figureCaptionEl.setText(this.getCaptionFieldValue());
     }

--- a/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
@@ -30,6 +30,7 @@ import {Style} from '../../styles/Style';
 import {HTMLAreaHelper} from '../../HTMLAreaHelper';
 import {ImageUrlBuilder, ImageUrlParameters} from '../../../../../util/ImageUrlResolver';
 import {StyleHelper} from '../../styles/StyleHelper';
+import {HtmlEditor} from '../../HtmlEditor';
 
 export class ImageModalDialog
     extends OverrideNativeDialog {
@@ -95,8 +96,8 @@ export class ImageModalDialog
 
         if (this.presetImageEl) {
             const presetStyles = !!presetFigureEl ? presetFigureEl.getAttribute('class') : '';
-            if (presetFigureEl) {
-                this.figure.getHTMLElement().style.width = presetFigureEl.getStyle('width');
+            if (presetFigureEl && presetFigureEl.hasAttribute('style')) {
+                this.figure.getEl().setAttribute('style', presetFigureEl.getAttribute('style'));
             }
             this.presetImage(presetStyles);
         }
@@ -493,10 +494,11 @@ export class ImageModalDialog
         const figureEl: CKEDITOR.dom.element = <CKEDITOR.dom.element>imageEl.getAscendant('figure');
         const figureCaptionEl: CKEDITOR.dom.element = figureEl.findOne('figcaption');
 
-        figureEl.setAttribute('class', `${this.figure.getClass()} captioned`);
+        figureEl.setAttribute('class', `${this.figure.getClass()}`);
         figureEl.removeAttribute('style');
-        if (this.figure.hasClass(StyleHelper.STYLE.WIDTH.CUSTOM)) {
-            figureEl.setStyle('width', this.figure.getHTMLElement().style.width);
+
+        if (this.figure.getEl().hasAttribute('style') && !!this.figure.getEl().getAttribute('style')) {
+            figureEl.setAttribute('style', this.figure.getEl().getAttribute('style'));
         }
 
         imageEl.removeAttribute('class');
@@ -578,10 +580,6 @@ export class ImageModalDialog
         return (<any>this.getElemFromOriginalDialog('info', 'alignment')).getChild(0);
     }
 
-    private getOriginalLockElem(): CKEDITOR.dom.element {
-        return (<any>this.getElemFromOriginalDialog('info', 'lock')).getElement().getChild(0);
-    }
-
     isDirty(): boolean {
         return AppHelper.isDirty(this);
     }
@@ -597,7 +595,10 @@ export class ImageModalDialog
     }
 
     private applyStylingToPreview(classNames: string) {
-        this.figure.setClass(classNames);
+        this.figure.setClass('captioned ' + classNames);
+        const ckeFigure: CKEDITOR.dom.element = new CKEDITOR.dom.element(this.figure.getHTMLElement());
+        HtmlEditor.updateFigureInlineStyle(ckeFigure);
+        HtmlEditor.sortFigureClasses(ckeFigure);
     }
 }
 

--- a/src/main/resources/assets/styles/inputtype/text/htmlarea/image-dialog.less
+++ b/src/main/resources/assets/styles/inputtype/text/htmlarea/image-dialog.less
@@ -133,10 +133,6 @@
             font-size: 18px;
             background-color: transparent;
 
-            &:first-child {
-              padding-left: 0;
-            }
-
             &:before {
               display: block;
             }


### PR DESCRIPTION
-Setting inline alignment styles (same as in xp/styles.css) so alignment works in inline mode
-Controlling order of values in 'class' and 'style' attributes because cke rearranges those internally and wizard treats content as changed in spite of only order of styles or classes changed; see https://github.com/ckeditor/ckeditor-dev/issues/989